### PR TITLE
Add a new prototype

### DIFF
--- a/DongbosPrototype/Modules/ARMTemplateDSL/ARMTemplateDSL.psm1
+++ b/DongbosPrototype/Modules/ARMTemplateDSL/ARMTemplateDSL.psm1
@@ -1,0 +1,331 @@
+using namespace System.Text
+using namespace System.Collections.Generic
+using namespace System.Reflection;
+using namespace System.Management.Automation.Language
+
+class secureObject {  }
+
+enum ArmParamType
+{
+    string
+    securestring
+    int
+    bool
+    object
+    secureObject
+    array
+}
+
+$Script:contextStack = [stack[object]]::new()
+$Script:resources = [Dictionary[string, object]]::new([StringComparer]::OrdinalIgnoreCase)
+$Script:expressions = [HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+
+#region Helpers
+
+function GetParamType ([string] $type)
+{
+    return ([enum]::Parse([ArmParamType], $type, $true)).ToString()
+}
+
+function AlterParamBlock ([scriptblock] $sb)
+{
+    $sbAst = $sb.Ast
+    $oldParams = $sbAst.ParamBlock.Parameters
+    $newParams = [List[ParameterAst]]::new()
+    foreach ($param in $oldParams) {
+        $newParam = [ParameterAst]::new($param.Extent, $param.Name.Copy(), $null, $null)
+        $newParams.Add($newParam)
+    }
+
+    $newParamBlock = [ParamBlockAst]::new($sbAst.ParamBlock.Extent, $null, $newParams)
+    $newEndBlock = $sbAst.EndBlock.Copy()
+    $newSBAst = [ScriptBlockAst]::new($sbAst.Extent, $newParamBlock, $null, $null, $newEndBlock, $null)
+
+    return $newSBAst.GetScriptBlock()
+}
+
+function GetSessionState ([scriptblock] $sb)
+{
+    $flags = [BindingFlags]::NonPublic -bor [BindingFlags]::Instance
+    $p1 = [scriptblock].GetProperty("SessionStateInternal", $flags)
+    return $p1.GetValue($sb)
+}
+
+function SetSessionState ([scriptblock] $sb, $ssi)
+{
+    $flags = [BindingFlags]::NonPublic -bor [BindingFlags]::Instance
+    $p1 = [scriptblock].GetProperty("SessionStateInternal", $flags)
+    $p1.SetValue($sb, $ssi)
+}
+
+function QuoteAsNeeded ([string] $value)
+{
+    if ($Script:expressions.Contains($value)) {
+        return $value.Trim([char[]]('[',']'))
+    }
+
+    return "'$value'"
+}
+
+function Concat
+{
+    param(
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
+        [string] $Item1,
+
+        [Parameter(Mandatory, Position = 1, ValueFromPipeline)]
+        [string] $Item2,
+
+        [Parameter(ValueFromRemainingArguments)]
+        [string[]] $AdditionalItems
+    )
+
+    Process {
+        $list = [List[string]]::new()
+        $list.Add((QuoteAsNeeded $Item1))
+        $list.Add((QuoteAsNeeded $Item2))
+
+        foreach ($item in $AdditionalItems) {
+            $list.Add((QuoteAsNeeded $item))
+        }
+
+        $combined = $list -join ", "
+        $retValue = "[concat($combined)]"
+        $Script:expressions.Add($retValue) > $null
+
+        Write-Output $retValue
+    }
+}
+
+function ResourceId
+{
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string] $ResourceName
+    )
+
+    $resType = QuoteAsNeeded $Script:resources[$ResourceName].Type
+    $resName = QuoteAsNeeded $ResourceName
+
+    $resId = "[resourceId($resType, $resName)]"
+    $Script:expressions.Add($resId) > $null
+
+    if ($Script:contextStack.Count -gt 0) {
+        $context = $Script:contextStack.Peek()
+        $context.ResourceRef.DependsOn += $resId
+    }
+
+    return $resId
+}
+
+function GetModuleName ([string] $ResourceType)
+{
+    $ResourceType -replace '/', '.'
+}
+
+#endregion
+
+function Template
+{
+    param(
+        [Parameter(Mandatory)]
+        [string] $ContentVersion,
+
+        [Parameter(Mandatory, Position = 0)]
+        [scriptblock] $Body
+    )
+
+    try {
+        $template = [ordered]@{
+            '$schema' = "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"
+            contentVersion = $ContentVersion
+        }
+
+        if ($null -ne $Body.Ast.ParamBlock) {
+            $params = $Body.Ast.ParamBlock.Parameters
+            $armParameters = [ordered]@{}
+            $arguments = @()
+
+            foreach ($param in $params) {
+                $name = $param.Name.VariablePath.UserPath
+                $type = $param.StaticType.Name
+                $armParameters[$name] = @{ type = GetParamType -type $type }
+
+                $argument = "[parameters('$name')]"
+                $Script:expressions.Add($argument) > $null
+                $arguments += $argument
+            }
+
+            $template['parameters'] = $armParameters
+            $newBody = AlterParamBlock $Body
+            $ssi = GetSessionState -sb $Body
+            SetSessionState -sb $newBody -ssi $ssi
+
+            $results = & $newBody @arguments
+        }
+        else {
+            $results = & $Body
+        }
+
+        if ($null -ne $results) {
+            $resources = [List[object]]::new()
+            $outputs = @{}
+
+            foreach ($item in $results) {
+                switch ($item.Type) {
+                    'Resource' { $resources.Add($item.Payload) > $null }
+                    'output'   { $outputs.Add($item.Name, $item.Value) > $null }
+                }
+            }
+
+            if ($resources.Count -ne 0) {
+                $template['resources'] = $resources
+            }
+
+            if ($outputs.Count -ne 0) {
+                $template['outputs'] = $outputs
+            }
+        }
+
+        $template | ConvertTo-Json -Depth 10
+    }
+    finally {
+        $Script:contextStack.Clear()
+        $Script:resources.Clear()
+        $Script:expressions.Clear()
+    }
+}
+
+function Output
+{
+    [OutputType([hashtable])]
+    param(
+        [ArmParamType] $Type = 'string',
+
+        [Parameter(Mandatory, Position = 0)]
+        [string] $Name,
+
+        [Parameter(Mandatory, Position = 1)]
+        [string] $Value
+    )
+
+    $retValue = [ordered]@{ type = $Type.ToString(); value = $Value }
+    return @{ Name = $Name; Value = $retValue; Type = 'output' }
+}
+
+function Resource
+{
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [string] $Name,
+
+        [Parameter(Mandatory)]
+        [string] $ApiVersion,
+
+        [Parameter(Mandatory)]
+        [string] $Location,
+
+        [Parameter(Mandatory)]
+        [string] $Type,
+
+        [Parameter(Position = 0)]
+        [scriptblock] $Body
+    )
+
+    Process {
+        $expando = [ordered]@{
+            apiVersion = $ApiVersion
+            type = $Type
+            name = $Name
+            location = $Location
+        }
+
+        if ($null -ne $Body) {
+            try {
+                $context = @{
+                    ResourceType = $Type
+                    SchemaName = ''
+                    DependsOn = @()
+                }
+                $Script:contextStack.Push($context)
+
+                $properties = [ordered]@{}
+                $results = & $Body
+                switch ($results) {
+                    { $_.Type -eq 'Property' } {
+                        $properties[$_.Name] = $_.Value
+                    }
+                    default { throw "$($_.Type) not supported yet." }
+                }
+
+                if ($properties.Count -gt 0) {
+                    $expando.properties = $properties
+                }
+
+                if ($context.DependsOn.Count -ne 0) {
+                    $expando.dependsOn = $context.DependsOn
+                }
+            }
+            finally {
+                $Script:contextStack.Pop() > $null
+            }
+        }
+
+        $Script:resources.Add($expando.Name, $expando)
+        Write-Output @{ Type = 'Resource'; Payload = $expando }
+    }
+}
+
+function Property
+{
+    [OutputType([hashtable])]
+    [CmdletBinding(DefaultParameterSetName = 'Complex')]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string] $Name,
+
+        [Parameter(Mandatory, Position = 1, ParameterSetName = 'Simple')]
+        [object] $Value,
+
+        [Parameter(Mandatory, Position = 1, ParameterSetName = 'Complex')]
+        [scriptblock] $Body
+    )
+
+    if ($PSCmdlet.ParameterSetName -eq 'Simple') {
+        return @{ Name = $Name; Value = $Value; Type = 'Property' }
+    }
+
+    $context = $Script:contextStack.Peek()
+    $moduleName = GetModuleName -ResourceType $context.ResourceType
+
+    $schema = & "$moduleName\Get-Schema" -name $context.SchemaName
+    $expectArray = $schema[$Name].Type -eq 'array'
+
+    try {
+        $Script:contextStack.Push(@{
+            ResourceType = $context.ResourceType
+            SchemaName = $schema[$Name].Command
+            ResourceRef = $context.ResourceRef ?? $context
+        })
+
+        $results = @(& $Body)
+
+        if ($results.Length -gt 1) {
+            return @{ Name = $Name; Value = $results; Type = 'Property' }
+        }
+        elseif ($results.Length -eq 1) {
+            if (-not $expectArray) {
+                $results = $results[0]
+            }
+            return @{
+                Name = $Name
+                Value = $results
+                Type = 'Property'
+            }
+        }
+    }
+    finally {
+        $Script:contextStack.Pop() > $null
+    }
+}

--- a/DongbosPrototype/Modules/Microsoft.Network.NetworkInterfaces/Microsoft.Network.NetworkInterfaces.psm1
+++ b/DongbosPrototype/Modules/Microsoft.Network.NetworkInterfaces/Microsoft.Network.NetworkInterfaces.psm1
@@ -1,0 +1,64 @@
+using namespace System.Collections.Generic
+
+## what data structure should be used to hold schema?
+## As a proof-of-concept sample, here I assume the schema only has info about available properties.
+$Script:schema = [Dictionary[string, object]]::new([StringComparer]::OrdinalIgnoreCase)
+
+$networkInterface = @{}
+$networkInterface['networkSecurityGroup'] = @{ Name = 'networkSecurityGroup'; Type = 'object'; Required = $false; Command = 'NetworkSecurityGroup' }
+$networkInterface['ipConfigurations'] = @{ Name = 'ipConfigurations'; Type = 'array'; Required = $false; Command = 'NetworkInterfaceIPConfiguration' }
+$networkInterface['dnsSettings'] = @{ Name = 'dnsSettings'; Type = 'object'; Required = $false; Command = 'NetworkInterfaceDnsSettings' }
+$networkInterface['enableAcceleratedNetworking'] = @{ Name = 'enableAcceleratedNetworking'; Type = 'boolean'; Required = $false; }
+$networkInterface['enableIPForwarding'] = @{ Name = 'enableIPForwarding'; Type = 'boolean'; Required = $false; }
+
+$networkInterfaceIPConfiguration = @{}
+$networkInterfaceIPConfiguration['subnet'] = @{ Name = 'subnet'; Type = 'object'; Required = $false; Command = 'Subnet' }
+$networkInterfaceIPConfiguration['privateIPAddress'] = @{ Name = 'privateIPAddress'; Type = 'string'; Required = $false; }
+
+$Script:schema[''] = $networkInterface
+$Script:schema['networkInterfaceIPConfiguration'] = $networkInterfaceIPConfiguration
+
+function Get-Schema
+{
+    [Parameter(Mandatory, Position = 0)]
+    param([string] $name)
+    return $Script:schema[$name]
+}
+
+function NetworkInterfaceIPConfiguration
+{
+    param(
+        [Parameter(Mandatory)]
+        [string] $Name,
+
+        [Parameter(Mandatory, Position = 0)]
+        [scriptblock] $Body
+    )
+
+    $expando = [ordered]@{ name = $Name }
+
+    $properties = [ordered]@{}
+    $results = & $Body
+    switch ($results) {
+        { $_.Type -eq 'Property' } {
+            $properties[$_.Name] = $_.Value
+        }
+        default { throw "$($_.Type) not supported yet." }
+    }
+
+    if ($properties.Count -gt 0) {
+        $expando.properties = $properties
+    }
+
+    return $expando
+}
+
+function Subnet
+{
+    param(
+        [Parameter(Mandatory)]
+        [string] $Id
+    )
+
+    return [ordered]@{ id = $Id }
+}

--- a/DongbosPrototype/Modules/Microsoft.Network.PublicIpAddresses/Microsoft.Network.PublicIpAddresses.psm1
+++ b/DongbosPrototype/Modules/Microsoft.Network.PublicIpAddresses/Microsoft.Network.PublicIpAddresses.psm1
@@ -1,0 +1,14 @@
+$Script:schema = [Dictionary[string, object]]::new([StringComparer]::OrdinalIgnoreCase)
+
+$publicIPAddress = @{}
+$publicIPAddress['publicIPAllocationMethod'] = @{ Name = 'publicIPAllocationMethod'; Type = 'enum'; Required = $false; Values = 'Static','Dynamic' }
+$publicIPAddress['publicIPAddressVersion'] = @{ Name = 'publicIPAddressVersion'; Type = 'enum'; Required = $false; Values = 'IPv4','IPv6' }
+
+$Script:schema[''] = $publicIPAddress
+
+function Get-Schema
+{
+    [Parameter(Mandatory, Position = 0)]
+    param([string] $name)
+    return $Script:schema[$name]
+}

--- a/DongbosPrototype/Modules/Microsoft.Network.VirtualNetworks.Subnets/Microsoft.Network.VirtualNetworks.Subnets.psm1
+++ b/DongbosPrototype/Modules/Microsoft.Network.VirtualNetworks.Subnets/Microsoft.Network.VirtualNetworks.Subnets.psm1
@@ -1,0 +1,14 @@
+$Script:schema = [Dictionary[string, object]]::new([StringComparer]::OrdinalIgnoreCase)
+
+$subnets = @{}
+$subnets['addressPrefix'] = @{ Name = 'addressPrefix'; Type = 'string'; Required = $false; }
+$subnets['addressPrefixes'] = @{ Name = 'addressPrefixes'; Type = 'array'; Required = $false; }
+
+$Script:schema[''] = $subnets
+
+function Get-Schema
+{
+    [Parameter(Mandatory, Position = 0)]
+    param([string] $name)
+    return $Script:schema[$name]
+}

--- a/DongbosPrototype/README.md
+++ b/DongbosPrototype/README.md
@@ -1,0 +1,70 @@
+## Idea of the Design
+
+In its simplest structure, a template has the following elements:
+
+```json
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "",
+  "apiProfile": "",
+  "parameters": {  },
+  "variables": {  },
+  "functions": [  ],
+  "resources": [  ],
+  "outputs": {  }
+}
+```
+
+The schema for a resource can be found [here](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/template-syntax#resources). Schemas for other elements of a template can also be found on the same page.
+
+For the common keys of a template and its elements (such as the keys of a resource),
+simple key/value pairs are treated as parameters,
+and complext key/value pairs are represented as functions.
+Parameters of a template are declared directly as a `ParamBlock`.
+
+For example,
+- `contentVersion`, `apiProfile` are parameters of the `Template` function.
+  `Template` takes a script block that declares the complex elements (object/array).
+- `parameters` are declared as a `ParamBlock` of the script block.
+- `resources` takes an array of resources. Function `Resource` is for declaring one resource.
+  The script block for `Template` can call `Resource` for one or more times
+  to declare one or more resources.
+- `outputs` take an object, each of whose properties is an output.
+  Function `Output` is for declaring one output.
+  The script block for `Template` can call `Output` for one or more times
+  to declare one or more outputs.
+- `properties` of a `resource` is an object, each of whose properties is a property.
+  Function `Property` is for declaring one property.
+
+The functions described so far are declared in the base `ARMTemplateDSL` module.
+This module only contains the function definitions for the common keys.
+
+The type of a resource is a combination of the namespace of the resource provider and the resource type
+(such as **Microsoft.Storage/storageAccounts**).
+Each type will have a corresponding PowerShell module,
+which has to be **auto-generated out of the schema of the resource type**.
+
+Each of such modules will need to implement the command `Get-Schema [-Name] <string>` 
+which returns schemas related to this resource, including:
+- schema of this resource itself
+- schemas of the objects used by this resource
+
+For each of the special objects used by the resource,
+a function will be defined for it in the module of that resource.
+Those functions will use some of the common functions from `ARMTemplateDSL`,
+such as the function `Property`.
+
+With `Get-Schema`, the common functions defined in `ARMTemplateDSL` module can query for the schema
+of a specific resource, or a specific property.
+The resource type will be specified when using the `Resource` function,
+so the module name can be inferred from the resource type,
+and then `$moduleName\Get-Schema` can be called to get the schemas of that resource.
+
+`Get-Schema` can help the tab completion as well.
+
+## Example
+
+[`basic.ps1`](./basic.ps1) is a sample of the DSL to generate [`basic.json`](./basic.json).
+To try it out, add the [`Modules`](./Modules) folder to your module path, and then run `basic.ps1`.
+It will generate the same JSON content as in [`basic.json`](./basic.json),
+which is copied from [`arm-templator-transpiler/tests/basic.json`](https://github.com/anthony-c-martin/arm-templator-transpiler/blob/master/tests/basic.json).

--- a/DongbosPrototype/basic.json
+++ b/DongbosPrototype/basic.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "rgLocation": {
+      "type": "string"
+    },
+    "namePrefix": {
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "apiVersion": "2019-11-01",
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "name": "[concat('myVnet/', parameters('namePrefix'), '-subnet')]",
+      "location": "[parameters('rgLocation')]",
+      "properties": {
+        "addressPrefix": "10.0.0.0/24"
+      }
+    },
+    {
+      "apiVersion": "2019-11-01",
+      "type": "Microsoft.Network/publicIpAddresses",
+      "name": "[concat(parameters('namePrefix'), '-pip1')]",
+      "location": "[parameters('rgLocation')]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic"
+      }
+    },
+    {
+      "apiVersion": "2019-11-01",
+      "type": "Microsoft.Network/publicIpAddresses",
+      "name": "[concat(parameters('namePrefix'), '-pip2')]",
+      "location": "[parameters('rgLocation')]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic"
+      }
+    },
+    {
+      "apiVersion": "2019-11-01",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(parameters('namePrefix'), '-nic')]",
+      "location": "[parameters('rgLocation')]",
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "myConfig",
+            "properties": {
+              "subnet": {
+                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', concat('myVnet/', parameters('namePrefix'), '-subnet'))]"
+              },
+              "privateIPAllocationMethod": "Dynamic"
+            }
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', concat('myVnet/', parameters('namePrefix'), '-subnet'))]"
+      ]
+    }
+  ],
+  "outputs": {
+    "nicResourceId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Network/networkInterfaces', concat(parameters('namePrefix'), '-nic'))]"
+    }
+  }
+}

--- a/DongbosPrototype/basic.ps1
+++ b/DongbosPrototype/basic.ps1
@@ -1,0 +1,42 @@
+$contentVersion = '1.0.0.0'
+$apiVersion = '2019-11-01'
+
+Template -ContentVersion $contentVersion {
+    param(
+        [string]$rgLocation,
+        [string]$namePrefix
+    )
+
+    $mySubnet = (Concat 'myVnet/' $namePrefix '-subnet')
+    Resource -Name $mySubnet `
+             -Location $rgLocation `
+             -ApiVersion $apiVersion `
+             -Type "Microsoft.Network/virtualNetworks/subnets" {
+        Property 'addressPrefix' '10.0.0.0/24'
+    }
+
+    '-pip1', '-pip2' | Concat $namePrefix |
+        Resource -Location $rgLocation -ApiVersion $apiVersion -Type 'Microsoft.Network/publicIpAddresses' {
+            Property 'publicIPAllocationMethod' 'Dynamic'
+        }
+
+    $myNic = (Concat $namePrefix '-nic')
+    Resource -Name $myNic `
+             -Location $rgLocation `
+             -ApiVersion $apiVersion `
+             -Type 'Microsoft.Network/networkInterfaces' {
+
+        ## 'Property' should be smart about its context.
+        ## For example, within this resource context, it should know 'ipConfigurations' expects an array.
+        Property 'ipConfigurations' {
+            NetworkInterfaceIPConfiguration -Name 'myConfig' {
+                Property 'subnet' {
+                    Subnet -Id (ResourceId $mySubnet)
+                }
+                Property 'privateIPAllocationMethod' 'Dynamic'
+            }
+        }
+    }
+
+    Output -Type string 'nicResourceId' (ResourceId $myNic)
+}


### PR DESCRIPTION
Add a new prototype for the ARM DSL.

Key ideas about the DSL:
- `parameters` are declared as the `ParamBlock` in a script block. All properties supported by a ARM parameter can be declared as script block parameters by using attributes.
- `resourceId` should automatically introduce dependency, without requiring the author to specify `dependsOn`.

Take a look at the sample file `basic.ps1` to get a rough idea of the DSL syntax.
To try it out, add the `Modules` folder to your module path, and then run `basic.ps1`.
It will generate the same JSON content as in `basic.json`,
which is copied from [`arm-templator-transpiler/tests/basic.json`](https://github.com/anthony-c-martin/arm-templator-transpiler/blob/master/tests/basic.json).

For additional information, please look at the `README.md`.