### PR TITLE
Fix generator to read flattened properties

### DIFF
--- a/sputnik.generator/rush.json
+++ b/sputnik.generator/rush.json
@@ -15,7 +15,7 @@
    * path segment in the "$schema" field for all your Rush config files.  This will ensure
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
-  "rushVersion": "5.23.0",
+  "rushVersion": "5.34.3",
   /**
    * The next field selects which package manager should be installed and determines its version.
    * Rush installs its own local copy of the package manager to ensure that your build process
@@ -49,7 +49,7 @@
    * Specify a SemVer range to ensure developers use a NodeJS version that is appropriate
    * for your repo.
    */
-  "nodeSupportedVersionRange": ">=8.9.4 <14.0.0",
+  "nodeSupportedVersionRange": ">=8.9.4 <15.0.0",
   "ensureConsistentVersions": true,
   "projectFolderMinDepth": 1,
   "projectFolderMaxDepth": 2,


### PR DESCRIPTION
Our generator plugin used to look only for a `properties` property on object schemas. Now it also looks through the other properties to see if they are flattened properties from a `properties` property...