### PR TITLE
Fix ability for `ConvertFrom-ArmTemplate` to accept relative path (or wildcards)

### DIFF
--- a/src/Commands/ConvertFromArmTemplateCommand.cs
+++ b/src/Commands/ConvertFromArmTemplateCommand.cs
@@ -6,6 +6,7 @@ using PSArm.Commands.Internal;
 using PSArm.Serialization;
 using PSArm.Templates;
 using System;
+using System.Collections.ObjectModel;
 using System.Management.Automation;
 
 namespace PSArm.Commands
@@ -49,9 +50,13 @@ namespace PSArm.Commands
                     return;
 
                 case "Path":
+                    ProviderInfo provider = null;
                     foreach (string path in Path)
                     {
-                        WriteObject(_parser.ParseFile(path));
+                        foreach (string resolvedPath in SessionState.Path.GetResolvedProviderPathFromPSPath(path, out provider))
+                        {
+                            WriteObject(_parser.ParseFile(resolvedPath));
+                        }
                     }
                     return;
 

--- a/test/pester/Conversion.Tests.ps1
+++ b/test/pester/Conversion.Tests.ps1
@@ -20,4 +20,14 @@ Describe "ARM conversion cmdlets" {
 
         Assert-StructurallyEqual -ComparisonObject $original -JsonObject $created
     }
+
+    It 'Can accept relative path' {
+        try {
+            Push-Location "$PSScriptRoot/assets"
+            ConvertFrom-ArmTemplate -Path ./roundtrip-template.json | Should -Not -BeNullOrEmpty
+        }
+        finally {
+            Pop-Location
+        }
+    }
 }


### PR DESCRIPTION
Need to resolve the path parameter value otherwise relative paths are not relative to current location (also affects ability to use wildcards to match files)